### PR TITLE
Replaced incompatible type union

### DIFF
--- a/termux/UI.py
+++ b/termux/UI.py
@@ -13,8 +13,9 @@
     toast - Show text as toast (transient popup)
 '''
 from .android import execute
+from typing import Union
 
-def __radiolike(func: str, opts: list | tuple, title: str):
+def __radiolike(func: str, opts: Union[list, tuple], title: str):
   v = ["-v"]
   v.append(','.join([str(i) for i in opts]))
   if title is not None:


### PR DESCRIPTION
 Type unions using the | operator are not supported on all versions of python, and not supported *at all* on pypy.

I replaced the offending operator with a union from typing, which should be more widely supported.